### PR TITLE
Build for end-to-end testing without 'progress' messages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -57,6 +57,9 @@
             "browserTarget": "angular-cli-circle:build"
           },
           "configurations": {
+            "ci": {
+              "progress": false
+            },
             "production": {
               "browserTarget": "angular-cli-circle:build:production"
             }
@@ -110,6 +113,10 @@
             "devServerTarget": "angular-cli-circle:serve"
           },
           "configurations": {
+            "ci": {
+              "devServerTarget": "angular-cli-circle:serve:ci",
+              "protractorConfig": "./e2e/circle-protractor.conf.js"
+            },
             "production": {
               "devServerTarget": "angular-cli-circle:serve:production"
             }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "testCircle": "ng test --karma-config=./src/circle-karma.conf.js --environment=prod --source-map=false --watch=false --progress=false",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "e2eCircle": "ng e2e --prod --protractor-config=./e2e/circle-protractor.conf.js"
+    "e2eCircle": "ng e2e --configuration=ci"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This PR eliminates progress messages during the build for e2e testing. It:
- adds a "ci" configuration to the dev server target under "serve";
- sets the "progress" flag to false;
- adds a reference to the new "ci" configuration to the "e2e" architect

Reference: the PR follows these instructions over at the Angular CLI (https://github.com/angular/angular-cli/issues/11412#issuecomment-412021539)